### PR TITLE
upgrade apim sdk to 8.0 fix build errors

### DIFF
--- a/src/ApiManagement/ApiManagement.ServiceManagement.Test/ApiManagement.ServiceManagement.Test.csproj
+++ b/src/ApiManagement/ApiManagement.ServiceManagement.Test/ApiManagement.ServiceManagement.Test.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="7.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="8.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApiManagement/ApiManagement.ServiceManagement/ApiManagement.ServiceManagement.csproj
+++ b/src/ApiManagement/ApiManagement.ServiceManagement/ApiManagement.ServiceManagement.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="7.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="8.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApiManagement/ApiManagement.ServiceManagement/ApiManagementClient.cs
+++ b/src/ApiManagement/ApiManagement.ServiceManagement/ApiManagementClient.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
                 cfg
                     .CreateMap<PsApiManagementRepresentation, RepresentationContract>()
                     .ForMember(dest => dest.ContentType, opt => opt.MapFrom(src => src.ContentType))
-                    .ForMember(dest => dest.Sample, opt => opt.MapFrom(src => src.Sample))
+                    //TODO Map To Example
+                    //.ForMember(dest => dest.Sample, opt => opt.MapFrom(src => src.Sample))
                     .ForMember(dest => dest.FormParameters, opt => opt.Ignore())
                     .ForMember(dest => dest.SchemaId, opt => opt.MapFrom(src => src.SchemaId))
                     .ForMember(dest => dest.TypeName, opt => opt.MapFrom(src => src.TypeName))
@@ -205,7 +206,8 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
                 cfg
                    .CreateMap<RepresentationContract, PsApiManagementRepresentation>()
                    .ForMember(dest => dest.ContentType, opt => opt.MapFrom(src => src.ContentType))
-                   .ForMember(dest => dest.Sample, opt => opt.MapFrom(src => src.Sample))
+                   //TODO Map To Example
+                   //.ForMember(dest => dest.Sample, opt => opt.MapFrom(src => src.Sample))
                    .ForMember(dest => dest.FormParameters, opt => opt.Ignore())
                    .ForMember(dest => dest.SchemaId, opt => opt.MapFrom(src => src.SchemaId))
                    .ForMember(dest => dest.TypeName, opt => opt.MapFrom(src => src.TypeName))
@@ -783,7 +785,7 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
                 Description = description,
                 ServiceUrl = serviceUrl,
                 Path = urlSuffix,
-                Protocols = Mapper.Map<IList<Protocol?>>(urlSchema),
+                Protocols = Mapper.Map<IList<string>>(urlSchema),
             };
 
             if (!string.IsNullOrWhiteSpace(authorizationServerId))
@@ -922,7 +924,7 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
             if (urlSchema != null)
             {
                 urlSchema = urlSchema.Distinct().ToArray();
-                api.Protocols = Mapper.Map<IList<Protocol?>>(urlSchema);
+                api.Protocols = Mapper.Map<IList<string>>(urlSchema);
             }
 
             if (subscriptionRequired)
@@ -1008,7 +1010,7 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
 
             if (protocols != null)
             {
-                apiCreateOrUpdateParams.Protocols = Mapper.Map<IList<Protocol?>>(protocols);
+                apiCreateOrUpdateParams.Protocols = Mapper.Map<IList<string>>(protocols);
             }
 
             if (!string.IsNullOrEmpty(serviceUrl))
@@ -1070,7 +1072,7 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement
 
             if (protocols != null)
             {
-                createOrUpdateContract.Protocols = Mapper.Map<IList<Protocol?>>(protocols);
+                createOrUpdateContract.Protocols = Mapper.Map<IList<string>>(protocols);
             }
 
             if (!string.IsNullOrEmpty(serviceUrl))

--- a/src/ApiManagement/ApiManagement.ServiceManagement/Commands/NewAzureApiManagementApi.cs
+++ b/src/ApiManagement/ApiManagement.ServiceManagement/Commands/NewAzureApiManagementApi.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement.Commands
         [Parameter(
             ValueFromPipelineByPropertyName = true,
             Mandatory = true,
-            HelpMessage = "Web API protocols (http, https). Protocols over which API is made available. " +
+            HelpMessage = "Web API protocols (http, https, ws, wss). Protocols over which API is made available. " +
                           "This parameter is required. Default value is $null.")]
         [ValidateNotNullOrEmpty]
         public PsApiManagementSchema[] Protocols { get; set; }

--- a/src/ApiManagement/ApiManagement.ServiceManagement/Models/PsApiManagementRepresentation.cs
+++ b/src/ApiManagement/ApiManagement.ServiceManagement/Models/PsApiManagementRepresentation.cs
@@ -20,8 +20,9 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement.Models
     {
         public string ContentType { get; set; }
 
-        public string Sample { get; set; }
-        
+        //TODO Map To Example
+        //public string Sample { get; set; }
+
         public PsApiManagementParameter[] FormParameters { get; set; }
                 
         public string SchemaId { get; set; }

--- a/src/ApiManagement/ApiManagement.ServiceManagement/Models/PsApiManagementSchema.cs
+++ b/src/ApiManagement/ApiManagement.ServiceManagement/Models/PsApiManagementSchema.cs
@@ -17,6 +17,8 @@ namespace Microsoft.Azure.Commands.ApiManagement.ServiceManagement.Models
     public enum PsApiManagementSchema
     {
         Http = 1,
-        Https = 2
+        Https = 2,
+        Ws = 3,
+        Wss = 4
     }
 }

--- a/src/ApiManagement/ApiManagement.Test/ApiManagement.Test.csproj
+++ b/src/ApiManagement/ApiManagement.Test/ApiManagement.Test.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="7.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="8.0.0-preview" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ApiManagement/ApiManagement/ApiManagement.csproj
+++ b/src/ApiManagement/ApiManagement/ApiManagement.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="6.2.2" />
-    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="7.0.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="8.0.0-preview" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Update SDK to 8.0.0

Api Protocol and Representation Sample caused build to fail.

Commented out the Representation Sample for now (Kacie should have task to implement Example)
Changed code to handle Protocol changes, so code can build again.